### PR TITLE
Replace eval with parseInt for afterTax input

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -30,7 +30,7 @@ function ContributionsHandler(db) {
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
         const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
+        const afterTax = parseInt(req.body.afterTax);
         const roth = eval(req.body.roth);
 
         /*


### PR DESCRIPTION
Replaced eval with parseInt for afterTax to improve security.